### PR TITLE
Put all destinations in one Navigation Graph

### DIFF
--- a/app/src/main/java/ir/nevercom/somu/MainActivity.kt
+++ b/app/src/main/java/ir/nevercom/somu/MainActivity.kt
@@ -6,26 +6,16 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.core.view.WindowCompat
-import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.navArgument
-import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dagger.hilt.android.AndroidEntryPoint
 import ir.nevercom.somu.model.ModelPreferencesManager
 import ir.nevercom.somu.repositories.UserRepository
-import ir.nevercom.somu.ui.Screen
 import ir.nevercom.somu.ui.screen.MainScreen
-import ir.nevercom.somu.ui.screen.login.LoginScreen
-import ir.nevercom.somu.ui.screen.movieDetails.MovieDetailsScreen
-import ir.nevercom.somu.ui.screen.person.PersonScreen
 import ir.nevercom.somu.ui.theme.SomuTheme
 import javax.inject.Inject
 
@@ -64,57 +54,9 @@ class MainActivity : ComponentActivity() {
                         color = MaterialTheme.colors.background,
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        AppContent(userRepository)
+                        MainScreen(userRepository)
                     }
                 }
-            }
-        }
-    }
-
-    @Composable
-    private fun AppContent(userRepository: UserRepository) {
-        val navController = rememberNavController()
-
-        val startDestination = if (userRepository.isLoggedIn()) "main" else "login"
-        NavHost(navController = navController, startDestination = startDestination) {
-            composable("main") {
-                MainScreen(
-                    onMovieClicked = { id ->
-                        navController.navigate(Screen.MovieDetails.createRoute(id))
-                    }
-                )
-            }
-            composable(Screen.Login.route) {
-                LoginScreen(
-                    onLoggedIn = {
-                        navController.navigate("main") {
-                            popUpTo(Screen.Login.route) { inclusive = true }
-                        }
-                    }
-                )
-            }
-            composable(
-                route = Screen.MovieDetails.route,
-                arguments = listOf(navArgument("id") { type = NavType.IntType })
-            ) {
-                MovieDetailsScreen(
-                    onBackClicked = { navController.popBackStack() },
-                    onPersonClicked = { id ->
-                        navController.navigate(Screen.PersonDetails.createRoute(id))
-                    }
-                )
-            }
-            composable(
-                route = Screen.PersonDetails.route,
-                arguments = listOf(navArgument("id") { type = NavType.IntType })
-            ) {
-                PersonScreen(
-                    onBackClicked = { navController.popBackStack() },
-                    onMovieClicked = { id ->
-                        navController.navigate(Screen.MovieDetails.createRoute(id))
-                    },
-                    onShowClicked = { id -> },
-                )
             }
         }
     }

--- a/app/src/main/java/ir/nevercom/somu/ui/screen/MainScreen.kt
+++ b/app/src/main/java/ir/nevercom/somu/ui/screen/MainScreen.kt
@@ -10,28 +10,32 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavType
+import androidx.navigation.compose.*
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.rememberInsetsPaddingValues
 import com.google.accompanist.insets.ui.BottomNavigation
 import com.google.accompanist.insets.ui.TopAppBar
 import ir.nevercom.somu.R
+import ir.nevercom.somu.repositories.UserRepository
 import ir.nevercom.somu.ui.NavScreen
+import ir.nevercom.somu.ui.Screen
 import ir.nevercom.somu.ui.screen.home.HomeContent
+import ir.nevercom.somu.ui.screen.login.LoginScreen
+import ir.nevercom.somu.ui.screen.movieDetails.MovieDetailsScreen
+import ir.nevercom.somu.ui.screen.person.PersonScreen
 import ir.nevercom.somu.ui.screen.search.SearchScreen
-import ir.nevercom.somu.ui.theme.SomuTheme
 import ir.nevercom.somu.ui.theme.bgColorEdge
 
 @Composable
-fun MainScreen(onMovieClicked: (movieId: Int) -> Unit) {
+fun MainScreen(userRepository: UserRepository) {
     val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
     val navScreens = listOf(
         NavScreen.Home,
         NavScreen.Search,
@@ -40,56 +44,57 @@ fun MainScreen(onMovieClicked: (movieId: Int) -> Unit) {
     )
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(id = R.string.app_name)) },
-                backgroundColor = Color.Transparent,
-                contentColor = Color.White,
-                elevation = 0.dp,
-                contentPadding = rememberInsetsPaddingValues(
-                    insets = LocalWindowInsets.current.statusBars,
-                    applyStart = true,
-                    applyTop = true,
-                    applyEnd = true,
+            if (currentDestination?.route in navScreens.associateBy { it.route }) {
+                TopAppBar(
+                    title = { Text(stringResource(id = R.string.app_name)) },
+                    backgroundColor = Color.Transparent,
+                    contentColor = Color.White,
+                    elevation = 0.dp,
+                    contentPadding = rememberInsetsPaddingValues(
+                        insets = LocalWindowInsets.current.statusBars,
+                        applyStart = true,
+                        applyTop = true,
+                        applyEnd = true,
+                    )
                 )
-            )
+            }
         },
         bottomBar = {
-            BottomNavigation(
-                backgroundColor = bgColorEdge,
-                contentColor = Color.White,
-                contentPadding = rememberInsetsPaddingValues(
-                    LocalWindowInsets.current.navigationBars
-                )
-            ) {
-                val navBackStackEntry by navController.currentBackStackEntryAsState()
-                val currentDestination = navBackStackEntry?.destination
-                navScreens.forEach { screen ->
-                    BottomNavigationItem(
-                        icon = { Icon(screen.icon, contentDescription = null) },
-                        label = { Text(screen.title) },
-                        selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
-                        onClick = {
-                            if (currentDestination?.hierarchy?.any { it.route == screen.route } == true) {
-                                return@BottomNavigationItem
-                            }
-                            navController.navigate(screen.route) {
-                                // Avoid multiple copies of the same destination when
-                                // reselecting the same item
-                                launchSingleTop = true
-                                // Restore state when reselecting a previously selected item
-                                restoreState = true
-                                // Pop up to the start destination of the graph to
-                                // avoid building up a large stack of destinations
-                                // on the back stack as users select items
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+            if (currentDestination?.route in navScreens.associateBy { it.route }) {
+                BottomNavigation(
+                    backgroundColor = bgColorEdge,
+                    contentColor = Color.White,
+                    contentPadding = rememberInsetsPaddingValues(
+                        LocalWindowInsets.current.navigationBars
+                    )
+                ) {
+                    navScreens.forEach { screen ->
+                        BottomNavigationItem(
+                            icon = { Icon(screen.icon, contentDescription = null) },
+                            label = { Text(screen.title) },
+                            selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
+                            onClick = {
+                                if (currentDestination?.hierarchy?.any { it.route == screen.route } == true) {
+                                    return@BottomNavigationItem
+                                }
+                                navController.navigate(screen.route) {
+                                    // Avoid multiple copies of the same destination when
+                                    // reselecting the same item
+                                    launchSingleTop = true
+                                    // Restore state when reselecting a previously selected item
+                                    restoreState = true
+                                    // Pop up to the start destination of the graph to
+                                    // avoid building up a large stack of destinations
+                                    // on the back stack as users select items
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
                                 }
                             }
-                        }
-                    )
+                        )
+                    }
                 }
             }
-
         }
     ) { innerPadding ->
         NavHost(
@@ -97,22 +102,56 @@ fun MainScreen(onMovieClicked: (movieId: Int) -> Unit) {
             startDestination = NavScreen.Home.route,
             Modifier.padding(innerPadding)
         ) {
+            val startDestination =
+                if (userRepository.isLoggedIn()) NavScreen.Home.route else Screen.Login.route
+            composable(Screen.Login.route) {
+                LoginScreen(
+                    onLoggedIn = {
+                        navController.navigate(NavScreen.Home.route) {
+                            popUpTo(Screen.Login.route) { inclusive = true }
+                        }
+                    }
+                )
+            }
             composable(NavScreen.Home.route) {
-                HomeContent(onMovieClicked = onMovieClicked)
+                HomeContent(
+                    onMovieClicked = { id ->
+                        navController.navigate(Screen.MovieDetails.createRoute(id))
+                    }
+                )
             }
             composable(NavScreen.Search.route) {
-                SearchScreen(onMovieClicked = onMovieClicked)
+                SearchScreen(
+                    onMovieClicked = { id ->
+                        navController.navigate(Screen.MovieDetails.createRoute(id))
+                    }
+                )
             }
             composable(NavScreen.Friends.route) { Text("Friends") }
             composable(NavScreen.Profile.route) { Text("Profile") }
+            composable(
+                route = Screen.MovieDetails.route,
+                arguments = listOf(navArgument("id") { type = NavType.IntType })
+            ) {
+                MovieDetailsScreen(
+                    onBackClicked = { navController.popBackStack() },
+                    onPersonClicked = { id ->
+                        navController.navigate(Screen.PersonDetails.createRoute(id))
+                    }
+                )
+            }
+            composable(
+                route = Screen.PersonDetails.route,
+                arguments = listOf(navArgument("id") { type = NavType.IntType })
+            ) {
+                PersonScreen(
+                    onBackClicked = { navController.popBackStack() },
+                    onMovieClicked = { id ->
+                        navController.navigate(Screen.MovieDetails.createRoute(id))
+                    },
+                    onShowClicked = { id -> },
+                )
+            }
         }
-    }
-}
-
-@Preview
-@Composable
-fun PreviewMainScreen() {
-    SomuTheme {
-        MainScreen({})
     }
 }


### PR DESCRIPTION
Previously, there were two separate navigation graphs: one for Main screen which housed BottomNavigation destinations with a Scaffold UI, and one for all other destinations that didn't belong in a Scaffold UI and were Fullscreen.

This approach while seemed cleaner, had it's disadvantages, messing up navigation stack for one.

In this approach which sopposedly is encouraged by Google, the Main UI is a Scaffold and all destinations are within this NavHost.
TopBar and BottomBar will show/hide based on current destination.